### PR TITLE
add tooling to find dead links

### DIFF
--- a/tools/find_dead_links.py
+++ b/tools/find_dead_links.py
@@ -1,0 +1,71 @@
+import yaml
+import requests
+from requests.exceptions import ConnectionError
+
+# Load the YAML file
+with open("accounts.yaml") as file:
+    data = yaml.safe_load(file)
+
+# Loop through each item in the YAML data
+for item in data:
+    print("Checking", item["name"])
+    name = item["name"]
+    accounts = item["accounts"]
+
+    # Check if the 'source' field is present
+    if "source" in item:
+        source = item["source"]
+
+        # If source is a list, loop through each URL
+        if isinstance(source, list):
+            for url in source:
+                if url.startswith("http"):
+                    try:
+                        response = requests.head(url, allow_redirects=False)
+                        response_code = response.status_code
+
+                        # Check if the response code is not 200 or 301
+                        if (
+                            response_code != 200
+                            and response_code != 301
+                            and response_code != 403
+                        ):
+                            print(f"URL: {url}")
+                            print(f"Response Code: {response_code}")
+                            print("----------------------")
+
+                    except ConnectionError as e:
+                        print(f"Error connecting to URL: {url}")
+                        print(f"Error message: {str(e)}")
+                        print("----------------------")
+                else:
+                    print(f"Invalid URL: {source}")
+                    print("----------------------")
+
+        # If source is a single URL, handle it directly
+        else:
+            if source.startswith("http"):
+                try:
+                    response = requests.head(source, allow_redirects=False)
+                    response_code = response.status_code
+
+                    # Check if the response code is not 200 or 301
+                    if (
+                        response_code != 200
+                        and response_code != 301
+                        and response_code != 403
+                    ):
+                        print(f"URL: {source}")
+                        print(f"Response Code: {response_code}")
+                        print("----------------------")
+
+                except ConnectionError as e:
+                    print(f"Error connecting to URL: {source}")
+                    print(f"Error message: {str(e)}")
+                    print("----------------------")
+            else:
+                print(f"Invalid URL: {source}")
+
+    else:
+        print(f"No source for {name}")
+        print("----------------------")


### PR DESCRIPTION
Add tooling to identify dead links - First output:

```
Checking Cloudhealth
Checking SegmentIO
Checking StackDriver
Checking Zencoder
URL: https://support.brightcove.com/using-zencoder-s3
Response Code: 404
----------------------
Checking Datadog
Checking Cloudability
URL: https://developers.cloudability.com/docs/vendor-credentials-end-point
Response Code: 404
----------------------
Checking Rackspace
Checking New Relic
Checking Brightcove
URL: https://support.brightcove.com/using-dynamic-ingest-s3
Response Code: 404
----------------------
Checking CloudCheckr
URL: https://support.cloudcheckr.com/cloudcheckr-api-userguide/cloudcheckr-admin-api-reference-guide/
Response Code: 302
----------------------
Checking SignifAI
Error connecting to URL: https://docs.signifai.io/docs/amazon-web-services
Error message: HTTPSConnectionPool(host='docs.signifai.io', port=443): Max retries exceeded with url: /docs/amazon-web-services (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x1039afd50>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
----------------------
Checking ParkMyCloud
Checking CenturyLinkCloud
Checking ELB logs
Checking Redshift logs
Checking Billing
Checking skeddly
Checking freshservice
URL: https://support.freshservice.com/support/solutions/articles/207515-creating-a-role-arn-for-integrating-amazon-web-services-aws-in-freshservice
Response Code: 302
----------------------
Checking signalfx
URL: https://signalfx-product-docs.readthedocs-hosted.com/en/latest/getting-started/send-data.html
Response Code: 302
----------------------
Checking cloudsploit
Checking globus
Checking dynatrace
Checking deepsecurity
Checking cloudbreak
Checking teraproc
Error connecting to URL: http://www.teraproc.com/awskey/
Error message: HTTPConnectionPool(host='www.teraproc.com', port=80): Max retries exceeded with url: /awskey/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x103b07550>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
----------------------
Checking orbitera
Error connecting to URL: https://support.orbitera.com/support/solutions/articles/147040-add-new-aws-accounts
Error message: HTTPSConnectionPool(host='support.orbitera.com', port=443): Max retries exceeded with url: /support/solutions/articles/147040-add-new-aws-accounts (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x103b07550>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
----------------------
Checking redline13
URL: https://www.redline13.com/blog/aws-setup/
Response Code: 404
----------------------
Checking kochava
Checking instaclustr
Checking CloudTrail
Checking Summit Route
Checking TrendMicro
URL: https://help.deepsecurity.trendmicro.com/Add-Computers/add-aws.html
Response Code: 404
----------------------
Checking Convox
URL: https://convox.com/docs/aws-integration
Response Code: 404
----------------------
Checking Spotinst
Checking Redlock
Checking Sumo Logic
URL: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/Grant-Access-to-an-AWS-Product
Response Code: 302
----------------------
Checking Bridgecrew
Checking Lacework
Checking Onelogin
Checking nOps
URL: https://help.nops.io/manual_setup
Response Code: 404
----------------------
Checking Fivetran
URL: https://fivetran.com/docs/logs/cloudwatch/setup-guide
Response Code: 302
----------------------
Checking Rapid7
Checking Databricks
Checking Threat Stack
Checking Cloudyn
Checking Lucidchart
Checking Workato
Checking Palo Alto Networks
Checking CloudZero
URL: https://www.cloudzero.com/hubfs/CloudZero%20Configuration%20Guide%20-%20Automated.pdf
Response Code: 404
----------------------
Checking Cloudinary
Checking Tenable
Checking Stitch
Checking Emnify
Checking Qualys Cloud View
Checking Auth0
Checking Altus
Checking AlertLogic
Checking CloudConformity
URL: https://github.com/cloudconformity/documentation-api/blob/master/Accounts.md#update-account
Response Code: 404
----------------------
Checking Nessus AWS Connector
Checking Dome9 Arc
Checking FortiCASB
Checking FortiCWP
Checking Azure Sentinel
No source for Azure Sentinel
----------------------
Checking Azure Billing Management
Checking ADC Application Deployment, ADM Delivery Management
Checking CloudManager for CloudVolumes
Checking Axonius.com
No source for Axonius.com
----------------------
Checking Fugue
No source for Fugue
----------------------
Checking CloudPhysics
Checking QRadar
No source for QRadar
----------------------
Checking LogicMonitor
No source for LogicMonitor
----------------------
Checking MVision ePO
Error connecting to URL: https://docs.mcafee.com/bundle/prod-name-n.n.x-guide-type/page/GUID-9B6E696A-78DA-4F41-A0FC-39699DD39639.html
Error message: HTTPSConnectionPool(host='docs.mcafee.com', port=443): Max retries exceeded with url: /bundle/prod-name-n.n.x-guide-type/page/GUID-9B6E696A-78DA-4F41-A0FC-39699DD39639.html (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1002)')))
----------------------
Checking Cloud Workload Protection
Checking Cloud Workload Protection
No source for Cloud Workload Protection
----------------------
Checking Logz.io
No source for Logz.io
----------------------
Checking Xi Frame
No source for Xi Frame
----------------------
Checking CloudWisdom, metricly
No source for CloudWisdom, metricly
----------------------
Checking Rockset
No source for Rockset
----------------------
Checking CloudHiro
Error connecting to URL: https://cloudhiro.com/AWS/AWSRegistrationGuide.php
Error message: HTTPSConnectionPool(host='cloudhiro.com', port=443): Max retries exceeded with url: /AWS/AWSRegistrationGuide.php (Caused by SSLError(CertificateError("hostname 'cloudhiro.com' doesn't match '*.cloudhiro.com'")))
----------------------
Checking Densify
URL: https://www.densify.com/docs/Content/Data_Collection_for_Public_Cloud_Systems/AWS_Data_Collection_Prerequisites_for_an_IAM_Role.htm
Response Code: 404
----------------------
Checking Armor Anywhere
URL: https://docs.armor.com/pages/viewpage.action?pageId=20709565
Response Code: 302
----------------------
Checking Genys
Checking site24x7
No source for site24x7
----------------------
Checking ylastic
Checking qubole
Checking Cloudability
URL: https://developers.cloudability.com/docs/vendor-credentials-end-point
Response Code: 404
----------------------
Checking VManage
Checking Cloud Applicatoin Manager
Checking Cloudaware
No source for Cloudaware
----------------------
Checking Cloud Ranger
No source for Cloud Ranger
----------------------
Checking FoxPass
Checking Nirmata
URL: https://nirmata-documentation.readthedocs.io/en/latest/CloudProviders.html
Response Code: 404
----------------------
Checking GitLab
No source for GitLab
----------------------
Checking Snyk
Checking CloudCraft
No source for CloudCraft
----------------------
Checking JupiterOne
Checking rev.com
URL: https://www.rev.com/api/s3bucketpolicy
Response Code: 404
----------------------
Checking Funnel
Checking Domo
URL: https://knowledge.domo.com/Connect/Connecting_to_Data_with_Connectors/Configuring_Each_Connector/Connectors_for_File_Retrieval/Amazon_S3_AssumeRole_Connector
Response Code: 302
----------------------
Checking Atlas DataLake
No source for Atlas DataLake
----------------------
Checking Upsolver
No source for Upsolver
----------------------
Checking Weave Cloud
Checking ChaosSearch
Checking EDB Postgres
No source for EDB Postgres
----------------------
Checking TheGlobalSolutions.net
No source for TheGlobalSolutions.net
----------------------
Checking wpengine
Checking cloudsqueeze
No source for cloudsqueeze
----------------------
Checking ThingSpace
URL: https://thingspace.verizon.com/resources/documentation/cloudconnector/Getting_Started/Streaming_to_AWS/
Response Code: 302
----------------------
Checking Anodot
Checking MediaMath
URL: https://apidocs.mediamath.com/reporting/log-level-data-service/overview#data-security-and-authorization
Response Code: 404
----------------------
Checking Presidio
Invalid URL: customer IAM policy
Checking Checkpoint Cloudguard
Checking Cisco Umbrella
Checking Cloudflare
Checking [Deprecated] AWS Log delivery Service
Checking Epsagon
URL: https://docs.epsagon.com/docs/faq
Response Code: 404
----------------------
Checking Turbot
URL: https://turbot.com/v5/docs/integrations/aws/import-aws-account
Response Code: 302
----------------------
Checking Qualys AWS EC2 Connector
Checking API Gateway
Checking Slack EKM
Checking SSLMate
Checking SSLMate (Sandbox Site)
```