### PR TITLE
Add OpsLevel account id

### DIFF
--- a/accounts.yaml
+++ b/accounts.yaml
@@ -364,3 +364,6 @@
 - name: 'SSLMate (Sandbox Site)'
   source: 'https://sslmate.com/help/reference/misc#aws_integration'
   accounts: ['056196542512']
+- name: 'OpsLevel'
+  source: 'https://docs.opslevel.com/docs/infrastructure'
+  accounts: ['746108190720']


### PR DESCRIPTION
The account id can be found on [this link](https://docs.opslevel.com/docs/infrastructure)