### PR TITLE
Add Github workflow to validate YAML schema

### DIFF
--- a/.github/workflows/validate-yaml-schema.yml
+++ b/.github/workflows/validate-yaml-schema.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Check schema
+        uses: lyubick/action-YAML-schema-validator@9106663958769c8d4f37b2faf1e6bb52cc87f820
+        with:
+          json-schema-file: schema.json
+          yaml-json-file-dir: accounts.yaml
+          recursive: false

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "source": {
+        "anyOf": [
+          { "type": "string" },
+          {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true
+          }
+        ]
+      },
+      "accounts": {
+        "type": "array",
+        "items": { "type": "string", "minLength": 12, "maxLength": 12 },
+        "uniqueItems": true
+      },
+      "type": {
+        "enum": ["aws"]
+      }
+    },
+    "required": ["name", "accounts"],
+    "additionalProperties": false
+  }
+}


### PR DESCRIPTION
This will allow us to ensure the YAML is well formatted in PRs. Note, we would like to make `source` a required field, but the YAML file currently fails this requirement.

Examples of failures:

When the source field is missing (NOTE: this is currently disabled because of violations)
```
 File `accounts.yaml` failed validation with >>>`'source' is a required property

Failed validating 'required' in schema['items']:
    {'additionalProperties': False,
     'properties': {'accounts': {'items': {'maxLength': 12,
                                           'minLength': 12,
                                           'type': 'string',
                                           'uniqueItems': True},
                                 'type': 'array'},
                    'name': {'type': 'string'},
                    'source': {'anyOf': [{'type': 'string'},
                                         {'items': {'type': 'string',
                                                    'uniqueItems': True},
                                          'type': 'array'}]},
                    'type': {'enum': ['aws']}},
     'required': ['name', 'source', 'accounts'],
     'type': 'object'}
```

When the accounts list is non-unique:
```
File `accounts.yaml` failed validation with >>>`['854209929931', '854209929931'] has non-unique elements

Failed validating 'uniqueItems' in schema['items']['properties']['accounts']:
    {'items': {'maxLength': 12, 'minLength': 12, 'type': 'string'},
     'type': 'array',
     'uniqueItems': True}
```