### PR TITLE
adding a crowdstrike account

### DIFF
--- a/accounts.yaml
+++ b/accounts.yaml
@@ -422,7 +422,7 @@
   accounts: ['758245563457']
 - name: 'CrowdStrike'
   source: ['https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-partner-providers.html']
-  accounts: ['517716713836']
+  accounts: ['517716713836','292230061137']
 - name: 'CyberArk'
   source: ['https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-partner-providers.html']
   accounts: ['749430749651']


### PR DESCRIPTION
adding a crowdstrike account per this documentation - https://d1.awsstatic.com/Marketplace/solutions-center/downloads/Crowdstrike-AWS-ControlTower-Implementation-Guide.pdf