### PR TITLE
Add Hava vendor

### DIFF
--- a/accounts.yaml
+++ b/accounts.yaml
@@ -724,3 +724,7 @@
 - name: 'Rafay'
   source: ['https://docs.rafay.co/learn/quickstart/som/eks/setup/']
   accounts: ['781965151837']
+- name:  'hava'
+  source: ['https://github.com/teamhava/hava-integration-controltower/blob/main/lambda/README.md']
+  accounts: ['281013829959']
+


### PR DESCRIPTION
The account is listed in the hava documentation and github here: https://github.com/teamhava/hava-integration-controltower/blob/main/lambda/README.md

<img width="1269" height="855" alt="image" src="https://github.com/user-attachments/assets/41a13b84-26f9-465a-9272-d000bb8448c6" />


<img width="1211" height="906" alt="image" src="https://github.com/user-attachments/assets/95071df9-cbc1-4f0d-b647-e7345b164983" />


https://docs.hava.io/integrations/terraform#example-usage