### PR TITLE
Additional AMI accounts

### DIFF
--- a/accounts.yaml
+++ b/accounts.yaml
@@ -751,5 +751,3 @@
 - name: 'Red Hat Enterprise Linux AMIs'
   source: ['https://access.redhat.com/solutions/15356']
   accounts: ['309956199498','219670896067']
-
-

--- a/accounts.yaml
+++ b/accounts.yaml
@@ -469,7 +469,7 @@
   source: ['https://mackerel.io/docs/entry/integrations/aws#:~:text=How%20to%20configure%20an%20IAM%20role']
   accounts: ['217452466226']
 - name: 'Canonical'
-  source: ['https://documentation.ubuntu.com/aws/aws-how-to/instances/find-ubuntu-images/']
+  source: ['https://ubuntu.com/server/docs/cloud-images/amazon-ec2','https://documentation.ubuntu.com/aws/aws-how-to/instances/find-ubuntu-images/']
   accounts: ['099720109477','513442679011','837727238323']
 - name: 'Archera'
   source: ['https://help.archera.ai/en/articles/5611146-what-is-the-archera-aws-account-id']

--- a/accounts.yaml
+++ b/accounts.yaml
@@ -748,5 +748,8 @@
     - 'https://anywhere.eks.amazonaws.com/docs/osmgmt/artifacts/'
     - 'https://registry.terraform.io/modules/rubrikinc/rubrik-cloud-cluster-elastic-storage/aws/1.6.0?tab=inputs'
   accounts: ['679593333241','345084742485']
+- name: 'Red Hat Enterprise Linux AMIs'
+  source: ['https://access.redhat.com/solutions/15356']
+  accounts: ['309956199498','219670896067']
 
 

--- a/accounts.yaml
+++ b/accounts.yaml
@@ -663,10 +663,10 @@
   source: ['https://docs.snowplow.io/docs/get-started/snowplow-bdp/private-managed-cloud/setup-guide-aws/']
   accounts: ['793733611312']
 - name: 'Qleet'
-  source: [' https://docs.qleet.io/guides/add-aws-account/']
+  source: ['https://docs.qleet.io/guides/add-aws-account/']
   accounts: ['983530947477']
 - name: 'Doppler'
-  source: [' https://docs.doppler.com/docs/aws-iam']
+  source: ['https://docs.doppler.com/docs/aws-iam']
   accounts: ['299900769157']
 - name: 'Improvado'
   source: ['https://improvado.io/docs/aws-s3-destination']

--- a/accounts.yaml
+++ b/accounts.yaml
@@ -741,5 +741,12 @@
 - name:  'RunsOn'
   source: ['https://runs-on.com/blog/official-runner-images-for-aws/']
   accounts: ['135269210855']
+- name: 'Marketplace'
+  type: 'aws'
+  source:
+    - 'https://documentation.ubuntu.com/aws/aws-how-to/instances/find-ubuntu-images/'
+    - 'https://anywhere.eks.amazonaws.com/docs/osmgmt/artifacts/'
+    - 'https://registry.terraform.io/modules/rubrikinc/rubrik-cloud-cluster-elastic-storage/aws/1.6.0?tab=inputs'
+  accounts: ['679593333241','345084742485']
 
 

--- a/accounts.yaml
+++ b/accounts.yaml
@@ -469,8 +469,8 @@
   source: ['https://mackerel.io/docs/entry/integrations/aws#:~:text=How%20to%20configure%20an%20IAM%20role']
   accounts: ['217452466226']
 - name: 'Canonical'
-  source: ['https://ubuntu.com/server/docs/cloud-images/amazon-ec2']
-  accounts: ['099720109477']
+  source: ['https://documentation.ubuntu.com/aws/aws-how-to/instances/find-ubuntu-images/']
+  accounts: ['099720109477','513442679011','837727238323']
 - name: 'Archera'
   source: ['https://help.archera.ai/en/articles/5611146-what-is-the-archera-aws-account-id']
   accounts: ['967800896805', '202754554539']


### PR DESCRIPTION
Changes:

- Update broken source for Canonical/Ubuntu

Additions:

- Additional Canonical AMI accounts (Ubuntu) from new source (commercial, GovCloud, and China partitions)
- Accounts storing AWS Marketplace AMIs (commercial and GovCloud partitions)
- Red Hat Enterprise Linux AMI accounts (commercial and GovCloud partitions)

Style:

- Delete trailing newlines in accounts.yaml
- Delete leading whitespace in 2 existing source URLs