### PR TITLE
Add Tableau AWS account entries

### DIFF
--- a/accounts.yaml
+++ b/accounts.yaml
@@ -755,6 +755,9 @@
   type: 'aws'
   source: ['https://docs.praetorian.com/articles/37956239205531-amazon-web-services-manual-deployment']
   accounts: ['992382785633']
+- name: 'Descope'
+  source: ['https://docs.descope.com/connectors/connector-configuration-guides/audit-and-troubleshooting/aws-s3']
+  accounts: ['312892722078']
 - name: 'Tableau'
   source: ['https://help.salesforce.com/s/articleView?id=005232922&type=1','https://help.tableau.com/current/online/en-us/activity_log_setup.htm']
   accounts: ['005102551263','075540750887','112108976196','119877853097','337853574888','349070092441','623102672691','667498515984','675003682462','792479604904','892386869973','943538517075']

--- a/accounts.yaml
+++ b/accounts.yaml
@@ -338,8 +338,8 @@
   source: ['https://docs.epsagon.com/docs/faq']
   accounts: ['066549572091']
 - name: 'Turbot'
-  source: ['https://turbot.com/v5/docs/integrations/aws/import-aws-account', 'https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-partner-providers.html']
-  accounts: ['287590803701', '255798382450', '453761072151']
+  source: ['https://turbot.com/v5/docs/integrations/aws/import-aws-account', 'https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-partner-providers.html', 'https://github.com/turbot/guardrails-samples/blob/main/queries/aws/aws_account_import.graphql']
+  accounts: ['287590803701', '255798382450', '453761072151', '525041748188']
 - name: 'Qualys AWS EC2 Connector'
   source: ['https://qualys-secure.force.com/discussions/s/question/0D52L00004TnxTqSAJ/aws-ec2-connector-creation-automation']
   accounts: ['805950163170']

--- a/accounts.yaml
+++ b/accounts.yaml
@@ -755,3 +755,6 @@
   type: 'aws'
   source: ['https://docs.praetorian.com/articles/37956239205531-amazon-web-services-manual-deployment']
   accounts: ['992382785633']
+- name: 'Tableau'
+  source: ['https://help.salesforce.com/s/articleView?id=005232922&type=1','https://help.tableau.com/current/online/en-us/activity_log_setup.htm']
+  accounts: ['005102551263','075540750887','112108976196','119877853097','337853574888','349070092441','623102672691','667498515984','675003682462','792479604904','892386869973','943538517075']


### PR DESCRIPTION
## Summary
- Adds 12 Tableau AWS account IDs
- Sources: Salesforce Help article and Tableau Online activity log setup docs

## Sources
- https://help.salesforce.com/s/articleView?id=005232922&type=1
- https://help.tableau.com/current/online/en-us/activity_log_setup.htm

🤖 Generated with [Claude Code](https://claude.com/claude-code)